### PR TITLE
Bump versions for slbeta3 in master branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,6 @@ jobs:
                   args:
                       push
               env:
+                  WORKING_DIR: ./teams
                   BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
                   

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more information, see module(s).
 1. Download and install Java SE Development Kit (JDK) version 11. You can install either [OpenJDK](https://adoptopenjdk.net/) or [Oracle JDK](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html).
    > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
  
-2. Download and install [Ballerina Swan Lake Beta2](https://ballerina.io/)
+2. Download and install [Ballerina Swan Lake Beta3](https://ballerina.io/)
 
 ### Building the source
  

--- a/teams/Dependencies.toml
+++ b/teams/Dependencies.toml
@@ -1,51 +1,49 @@
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "regex"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "crypto"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "time"
-version = "2.0.0-beta.2"
+version = "2.0.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "xmldata"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-beta.2"
+version = "0.8.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "io"
-version = "0.6.0-beta.2"
+version = "0.6.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "mime"
-version = "1.1.0-beta.2"
-
-
+version = "1.1.0-beta.3"

--- a/teams/Package.md
+++ b/teams/Package.md
@@ -7,7 +7,7 @@ This package provides the capability to access Microsoft Teams.
 ### Compatibility
 |                       | Version                    |
 |-----------------------|----------------------------|
-| Ballerina Language    | Ballerina Swan Lake Beta2  |
+| Ballerina Language    | Ballerina Swan Lake Beta3  |
 | Microsoft Graph API   | v1.0                       |
 
 ## Report issues


### PR DESCRIPTION
## Purpose
- Bump version to slbeta3 in Dependencies.toml, README.md and Package.md

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3-SNAPSHOT
